### PR TITLE
fix(AWS Lambda): add logs:TagResource permission to AWS Lambda IAM role

### DIFF
--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -140,6 +140,7 @@ If you are create a custom IAM Role with this policy, you will need to add a Tru
                 "iam:UpdateAssumeRolePolicy",
                 "s3:DeleteBucketPolicy",
                 "logs:CreateLogGroup",
+                "logs:TagResource",
                 "cloudformation:DescribeStacks",
                 "lambda:UpdateFunctionCode",
                 "s3:PutObject",

--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -196,6 +196,7 @@ resources:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
                     - logs:PutLogEvents
+                    - logs:TagResource
                   Resource:
                     - 'Fn::Join':
                       - ':'
@@ -260,6 +261,7 @@ resources:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
                     - logs:PutLogEvents
+                    - logs:TagResource
                   Resource:
                     - 'Fn::Join':
                       - ':'
@@ -298,6 +300,7 @@ resources:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
                     - logs:PutLogEvents
+                    - logs:TagResource
                   Resource:
                     - 'Fn::Join':
                       - ':'
@@ -358,6 +361,7 @@ resources:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
                     - logs:PutLogEvents
+                    - logs:TagResource
                   Resource:
                     - 'Fn::Join':
                       - ':'
@@ -397,6 +401,7 @@ resources:
                     - logs:CreateLogGroup
                     - logs:CreateLogStream
                     - logs:PutLogEvents
+                    - logs:TagResource
                   Resource:
                     - 'Fn::Join':
                       - ':'

--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -131,7 +131,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
         customResourceRole.Properties.Policies[0].PolicyDocument.Statement.push(
           {
             Effect: 'Allow',
-            Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
+            Action: ['logs:CreateLogStream', 'logs:CreateLogGroup', 'logs:TagResource'],
             Resource: [
               {
                 'Fn::Sub':

--- a/lib/plugins/aws/package/compile/events/cloud-front.js
+++ b/lib/plugins/aws/package/compile/events/cloud-front.js
@@ -632,7 +632,7 @@ class AwsCompileCloudFrontEvents {
         // to the function when you created it.
         Resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument.Statement.push({
           Effect: 'Allow',
-          Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+          Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents', 'logs:TagResource'],
           Resource: [{ 'Fn::Sub': 'arn:${AWS::Partition}:logs:*:*:*' }],
         });
       }

--- a/lib/plugins/aws/package/lib/iam-role-lambda-execution-template.json
+++ b/lib/plugins/aws/package/lib/iam-role-lambda-execution-template.json
@@ -21,7 +21,7 @@
           "Statement": [
             {
               "Effect": "Allow",
-              "Action": ["logs:CreateLogStream", "logs:CreateLogGroup"],
+              "Action": ["logs:CreateLogStream", "logs:CreateLogGroup", "logs:TagResource"],
               "Resource": []
             },
             {

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -299,7 +299,7 @@ describe('#addCustomResourceToService()', () => {
       expect(RoleProps.Policies[0].PolicyDocument.Statement).to.include.deep.members([
         {
           Effect: 'Allow',
-          Action: ['logs:CreateLogStream', 'logs:CreateLogGroup'],
+          Action: ['logs:CreateLogStream', 'logs:CreateLogGroup', 'logs:TagResource'],
           Resource: [
             {
               'Fn::Sub':

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -1168,7 +1168,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         Key: 'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json',
       })
       .returns({
-        Metadata: { filesha256: 'qxp+iwSTMhcRUfHzka4AE4XAWawS8GnEyBh1WpGb7Vw=' },
+        Metadata: { filesha256: 'ehiUQMDbrQnzl3h86rfG0T6nICXzNTiQ0xXZSuIw98s=' },
       });
     s3HeadObjectStub
       .withArgs({

--- a/test/unit/lib/plugins/aws/package/compile/events/cloud-front.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloud-front.test.js
@@ -941,7 +941,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js', 
       ).to.deep.include.members([
         {
           Effect: 'Allow',
-          Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+          Action: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents', 'logs:TagResource'],
           Resource: [{ 'Fn::Sub': 'arn:${AWS::Partition}:logs:*:*:*' }],
         },
       ]);

--- a/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
@@ -119,6 +119,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         expect(createLogStatement.Action).to.be.deep.equal([
           'logs:CreateLogStream',
           'logs:CreateLogGroup',
+          'logs:TagResource'
         ]);
         expect(createLogStatement.Resource).to.deep.includes({
           'Fn::Sub': `${arnLogPrefix}:log-group:/aws/lambda/${service}-dev*:*`,
@@ -141,6 +142,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         expect(createLogStatement.Action).to.be.deep.equal([
           'logs:CreateLogStream',
           'logs:CreateLogGroup',
+          'logs:TagResource'
         ]);
         expect(createLogStatement.Resource).to.deep.includes({
           'Fn::Sub': `${arnLogPrefix}:log-group:/aws/lambda/myCustomName:*`,


### PR DESCRIPTION
As announced by AWS in Dec 2022, there is a new API for tagging CloudWatch resources. New accounts/roles that need to tag CloudWatch LogGroups need the new logs:TagResouce permission.
